### PR TITLE
Replace migrating link to image

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install hexo-renderer-jade --save
 
 ## Probable solutions
 
-- Check version of hexo and review ![Migrating from 2.x to 3.0](https://github.com/hexojs/hexo/wiki/Migrating-from-2.x-to-3.0)
+- Check version of hexo and review [Migrating from 2.x to 3.0](https://github.com/hexojs/hexo/wiki/Migrating-from-2.x-to-3.0)
 - Check if your terminal's current directory is hexo's root directory which contains `source/`, `themes/`, etc.
 - Feel free to open an [issue](https://github.com/icylogic/carbon/issues/new)
 


### PR DESCRIPTION
Here is an image, that must be a link. I fix this.
